### PR TITLE
レスポンスクラスをレコードクラスに変更

### DIFF
--- a/src/main/java/com/udemy/videolist/application/controller/VideoCreateResponse.java
+++ b/src/main/java/com/udemy/videolist/application/controller/VideoCreateResponse.java
@@ -12,7 +12,8 @@ record VideoCreateResponse(
     int price) {
 
   public VideoCreateResponse(Video video) {
-    this("video successfully created",
+    this(
+        "video successfully created",
         video.getId(),
         video.getTitle(),
         video.getInstructor(),

--- a/src/main/java/com/udemy/videolist/application/controller/VideoCreateResponse.java
+++ b/src/main/java/com/udemy/videolist/application/controller/VideoCreateResponse.java
@@ -1,34 +1,24 @@
 package com.udemy.videolist.application.controller;
 
 import com.udemy.videolist.model.Video;
-import lombok.Getter;
 
-@Getter
-public class VideoCreateResponse {
-
-  private final String message;
-
-  private final int id;
-
-  private final String title;
-
-  private final String instructor;
-
-  private final String language;
-
-  private final Boolean isFree;
-
-  private final int price;
+record VideoCreateResponse(
+    String message,
+    int id,
+    String title,
+    String instructor,
+    String language,
+    Boolean isFree,
+    int price) {
 
   public VideoCreateResponse(Video video) {
-    this.message = "video successfully created";
-    this.id = video.getId();
-    this.title = video.getTitle();
-    this.instructor = video.getInstructor();
-    this.language = video.getLanguage();
-    this.isFree = video.getIsFree();
-    this.price = video.getPrice();
+    this("video successfully created",
+        video.getId(),
+        video.getTitle(),
+        video.getInstructor(),
+        video.getLanguage(),
+        video.getIsFree(),
+        video.getPrice()
+    );
   }
-
-  ;
 }

--- a/src/main/java/com/udemy/videolist/application/controller/VideoResponse.java
+++ b/src/main/java/com/udemy/videolist/application/controller/VideoResponse.java
@@ -4,6 +4,10 @@ import com.udemy.videolist.model.Video;
 
 record VideoResponse(int id, String title, String instructor, String language, int price) {
   public VideoResponse(Video video) {
-    this(video.getId(), video.getTitle(), video.getInstructor(), video.getLanguage(), video.getPrice());
+    this(video.getId(),
+        video.getTitle(),
+        video.getInstructor(),
+        video.getLanguage(),
+        video.getPrice());
   }
 }

--- a/src/main/java/com/udemy/videolist/application/controller/VideoResponse.java
+++ b/src/main/java/com/udemy/videolist/application/controller/VideoResponse.java
@@ -1,26 +1,9 @@
 package com.udemy.videolist.application.controller;
 
 import com.udemy.videolist.model.Video;
-import lombok.Getter;
 
-@Getter
-public class VideoResponse {
-
-  private final int id;
-
-  private final String title;
-
-  private final String instructor;
-
-  private final String language;
-
-  private final int price;
-
+record VideoResponse(int id, String title, String instructor, String language, int price) {
   public VideoResponse(Video video) {
-    this.id = video.getId();
-    this.title = video.getTitle();
-    this.instructor = video.getInstructor();
-    this.language = video.getLanguage();
-    this.price = video.getPrice();
+    this(video.getId(), video.getTitle(), video.getInstructor(), video.getLanguage(), video.getPrice());
   }
 }

--- a/src/main/java/com/udemy/videolist/application/controller/VideoResponse.java
+++ b/src/main/java/com/udemy/videolist/application/controller/VideoResponse.java
@@ -2,7 +2,13 @@ package com.udemy.videolist.application.controller;
 
 import com.udemy.videolist.model.Video;
 
-record VideoResponse(int id, String title, String instructor, String language, int price) {
+record VideoResponse(
+    int id,
+    String title,
+    String instructor,
+    String language,
+    int price) {
+
   public VideoResponse(Video video) {
     this(video.getId(),
         video.getTitle(),

--- a/src/main/java/com/udemy/videolist/application/controller/VideoUpdateResponse.java
+++ b/src/main/java/com/udemy/videolist/application/controller/VideoUpdateResponse.java
@@ -3,29 +3,22 @@ package com.udemy.videolist.application.controller;
 import com.udemy.videolist.model.Video;
 import lombok.Getter;
 
-@Getter
-public class VideoUpdateResponse {
+record VideoUpdateResponse(
+    String message,
+    String title,
+    String instructor,
+    String language,
+    Boolean isFree,
+    int price) {
 
-  private final String message;
-
-  private final String title;
-
-  private final String instructor;
-
-  private final String language;
-
-  private final Boolean isFree;
-
-  private final int price;
-
-  protected VideoUpdateResponse(Video video) {
-    this.message = "video successfully updated";
-    this.title = video.getTitle();
-    this.instructor = video.getInstructor();
-    this.language = video.getLanguage();
-    this.isFree = video.getIsFree();
-    this.price = video.getPrice();
+  public VideoUpdateResponse(Video video) {
+    this(
+        "video successfully updated",
+        video.getTitle(),
+        video.getInstructor(),
+        video.getLanguage(),
+        video.getIsFree(),
+        video.getPrice()
+    );
   }
-
-  ;
 }


### PR DESCRIPTION
## API実行時に返すレスポンスクラスをclassからrecordクラスに変更
**recordクラスはデータの保持と不変性を重視したデータモデルを表現するためのクラス。**

公式引用[(リンク)](https://docs.oracle.com/javase/jp/15/language/records.html)
> レコード・クラスは一連のフィールドを宣言し、適切なアクセッサ、コンストラクタ、equals、hashCodeおよび
toStringメソッドが自動的に作成されます。
このクラスは単純な「データキャリア」として機能することを意図しているため、フィールドはfinalです。

つまり
`record Rectangle(double length, double width) { }`
クラス宣言時にこのように宣言するだけで以下のものが自動的に生成される。
- privateかつfinalなフィールド
- 全てのフィールドの引数をもつコンストラクタ
- 適切にオーバーライドされたequals, hashCode, toStringメソッド

**※ 不変性が重視されているためsetterは生成されずフィールドはprivateかつfinalで修飾される**